### PR TITLE
Bugfix/read size 0

### DIFF
--- a/GTiff2Tiles.Core/GTiff2Tiles.Core.xml
+++ b/GTiff2Tiles.Core/GTiff2Tiles.Core.xml
@@ -1035,7 +1035,7 @@
         <member name="M:GTiff2Tiles.Core.GeoTiffs.Raster.Dispose(System.Boolean)">
             <inheritdoc />
         </member>
-        <member name="M:GTiff2Tiles.Core.GeoTiffs.Raster.CreateTileImage(NetVips.Image,GTiff2Tiles.Core.Tiles.RasterTile)">
+        <member name="M:GTiff2Tiles.Core.GeoTiffs.Raster.CreateTileImage(NetVips.Image,GTiff2Tiles.Core.Tiles.RasterTile,GTiff2Tiles.Core.Images.Area,GTiff2Tiles.Core.Images.Area)">
             <summary>
             Create <see cref="T:NetVips.Image"/> for one <see cref="T:GTiff2Tiles.Core.Tiles.RasterTile"/>
             from input <see cref="T:NetVips.Image"/> or tile cache
@@ -2445,7 +2445,7 @@
             <param name="tmsCompatible"></param>
             <exception cref="T:System.ArgumentOutOfRangeException"/>
         </member>
-        <member name="M:GTiff2Tiles.Core.Tiles.RasterTile.CreateImage(GTiff2Tiles.Core.GeoTiffs.IGeoTiff,NetVips.Image)">
+        <member name="M:GTiff2Tiles.Core.Tiles.RasterTile.CreateImage(GTiff2Tiles.Core.GeoTiffs.IGeoTiff,NetVips.Image,GTiff2Tiles.Core.Images.Area,GTiff2Tiles.Core.Images.Area)">
             <summary>
             Create <see cref="T:NetVips.Image"/> for one <see cref="T:GTiff2Tiles.Core.Tiles.RasterTile"/>
             from input <see cref="T:NetVips.Image"/> or tile cache
@@ -2453,6 +2453,8 @@
             <param name="sourceGeoTiff">Source <see cref="T:GTiff2Tiles.Core.GeoTiffs.IGeoTiff"/></param>
             <param name="tileCache">Source <see cref="T:NetVips.Image"/>
             or tile cache</param>
+            <param name="readArea">Source area</param>
+            <param name="writeArea">Tile write area</param>
             <returns>Ready <see cref="T:NetVips.Image"/> for <see cref="T:GTiff2Tiles.Core.Tiles.RasterTile"/></returns>
             <exception cref="T:System.ArgumentNullException"/>
             <exception cref="T:System.ArgumentException"/>

--- a/GTiff2Tiles.Core/Images/Area.cs
+++ b/GTiff2Tiles.Core/Images/Area.cs
@@ -64,7 +64,7 @@ public class Area
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="ArgumentException"/>
-    public static (Area readArea, Area writeArea) GetAreas(GeoCoordinate imageMinCoordinate,
+    public static (Area readArea, Area writeArea)? GetAreas(GeoCoordinate imageMinCoordinate,
                                                            GeoCoordinate imageMaxCoordinate, Size imageSize,
                                                            GeoCoordinate tileMinCoordinate,
                                                            GeoCoordinate tileMaxCoordinate, Size tileSize)
@@ -145,6 +145,9 @@ public class Area
 
         PixelCoordinate readOriginCoordinate = new(readPosMinX, readPosMinY);
         PixelCoordinate writeOriginCoordinate = new(writePosMinX, writePosMinY);
+
+        if (readXSize < 1 || readYSize < 1 || writeXSize < 1 || writeYSize < 1) return null;
+        
         Size readSize = new((int)readXSize, (int)readYSize);
         Size writeSize = new((int)writeXSize, (int)writeYSize);
 
@@ -162,7 +165,7 @@ public class Area
     /// <param name="tile">Target <see cref="ITile"/></param>
     /// <returns><see cref="ValueTuple{T1, T2}"/> of <see cref="Area"/>s to read and write</returns>
     /// <exception cref="ArgumentNullException"/>
-    public static (Area readArea, Area writeArea) GetAreas(IGeoTiff image, ITile tile)
+    public static (Area readArea, Area writeArea)? GetAreas(IGeoTiff image, ITile tile)
     {
         #region Preconditions checks
 

--- a/GTiff2Tiles.Core/Tiles/RasterTile.cs
+++ b/GTiff2Tiles.Core/Tiles/RasterTile.cs
@@ -58,7 +58,8 @@ public class RasterTile : Tile
     /// <param name="size"></param>
     /// <param name="tmsCompatible"></param>
     /// <exception cref="ArgumentOutOfRangeException"/>
-    public RasterTile(Number number, CoordinateSystem coordinateSystem, Size size = null, bool tmsCompatible = false) : base(number, coordinateSystem, size, tmsCompatible) { }
+    public RasterTile(Number number, CoordinateSystem coordinateSystem, Size size = null, bool tmsCompatible = false) :
+        base(number, coordinateSystem, size, tmsCompatible) { }
 
     /// <inheritdoc cref="Tile(GeoCoordinate,GeoCoordinate,int,Size,bool)"/>
     /// <param name="minCoordinate"></param>
@@ -67,7 +68,8 @@ public class RasterTile : Tile
     /// <param name="size"></param>
     /// <param name="tmsCompatible"></param>
     /// <exception cref="ArgumentOutOfRangeException"/>
-    public RasterTile(GeoCoordinate minCoordinate, GeoCoordinate maxCoordinate, int zoom, Size size = null, bool tmsCompatible = false) : base(minCoordinate, maxCoordinate, zoom, size, tmsCompatible) { }
+    public RasterTile(GeoCoordinate minCoordinate, GeoCoordinate maxCoordinate, int zoom, Size size = null,
+                      bool tmsCompatible = false) : base(minCoordinate, maxCoordinate, zoom, size, tmsCompatible) { }
 
     #endregion
 
@@ -82,51 +84,53 @@ public class RasterTile : Tile
     /// <param name="sourceGeoTiff">Source <see cref="IGeoTiff"/></param>
     /// <param name="tileCache">Source <see cref="Image"/>
     /// or tile cache</param>
+    /// <param name="readArea">Source area</param>
+    /// <param name="writeArea">Tile write area</param>
     /// <returns>Ready <see cref="Image"/> for <see cref="RasterTile"/></returns>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="ArgumentException"/>
-    public Image CreateImage(IGeoTiff sourceGeoTiff, Image tileCache)
+    public Image CreateImage(IGeoTiff sourceGeoTiff, Image tileCache, Area readArea, Area writeArea)
     {
         // TODO: check geotiff?
 
         #region Preconditions checks
 
         if (tileCache == null) throw new ArgumentNullException(nameof(tileCache));
+        if (readArea == null) throw new ArgumentNullException(nameof(readArea));
+        if (writeArea == null) throw new ArgumentNullException(nameof(writeArea));
 
         #endregion
 
-        // Get postitions and sizes for current tile
-        (Area readArea, Area writeArea)? areas = Area.GetAreas(sourceGeoTiff, this);
 
-        var image = Image.Black(Size.Width, Size.Height).NewFromImage(new int[BandsCount]);
+        // Scaling calculations
+        double xScale = (double)writeArea.Size.Width / readArea.Size.Width;
+        double yScale = (double)writeArea.Size.Height / readArea.Size.Height;
 
-        if (areas != null)
-        {
-            (Area readArea, Area writeArea) = areas.Value;
-            // Scaling calculations
-            double xScale = (double)writeArea.Size.Width / readArea.Size.Width;
-            double yScale = (double)writeArea.Size.Height / readArea.Size.Height;
+        // Crop and resize tile
+        Image tempTileImage = tileCache.Crop((int)readArea.OriginCoordinate.X, (int)readArea.OriginCoordinate.Y,
+                                             readArea.Size.Width, readArea.Size.Height)
+                                       .Resize(xScale, Interpolation, yScale);
 
-            // Crop and resize tile
-            Image tempTileImage = tileCache.Crop((int)readArea.OriginCoordinate.X, (int)readArea.OriginCoordinate.Y,
-                                                 readArea.Size.Width, readArea.Size.Height)
-                                           .Resize(xScale, Interpolation, yScale);
-
-            // Add alpha channel if needed
-            Band.AddDefaultBands(ref tempTileImage, BandsCount);
-            image=image.Insert(tempTileImage, (int)writeArea.OriginCoordinate.X, (int)writeArea.OriginCoordinate.Y);
-        }
+        // Add alpha channel if needed
+        Band.AddDefaultBands(ref tempTileImage, BandsCount);
 
         // Make transparent image and insert tile
-        return image;
+        return Image.Black(Size.Width, Size.Height).NewFromImage(new int[BandsCount])
+                    .Insert(tempTileImage, (int)writeArea.OriginCoordinate.X, (int)writeArea.OriginCoordinate.Y);
     }
 
     /// <inheritdoc />
     public override void WriteToFile(IGeoTiff sourceGeoTiff, IWriteTilesArgs args)
     {
+        // Get postitions and sizes for current tile
+        (Area readArea, Area writeArea)? areas = Area.GetAreas(sourceGeoTiff, this);
+
+        if (areas == null) return;
+
+        (Area readArea, Area writeArea) = areas.Value;
         WriteRasterTilesArgs rasterArgs = (WriteRasterTilesArgs)args;
 
-        using Image tileImage = CreateImage(sourceGeoTiff, rasterArgs.TileCache);
+        using Image tileImage = CreateImage(sourceGeoTiff, rasterArgs.TileCache, readArea, writeArea);
 
         tileImage.WriteToFile(Path);
     }
@@ -134,20 +138,26 @@ public class RasterTile : Tile
     /// <inheritdoc />
     public override IEnumerable<byte> WriteToEnumerable(IGeoTiff sourceGeoTiff, IWriteTilesArgs args)
     {
+        // Get postitions and sizes for current tile
+        (Area readArea, Area writeArea)? areas = Area.GetAreas(sourceGeoTiff, this);
+
+        if (areas == null) return null;
+
+        (Area readArea, Area writeArea) = areas.Value;
+
         WriteRasterTilesArgs rasterArgs = args as WriteRasterTilesArgs;
 
-        using Image tileImage = CreateImage(sourceGeoTiff, rasterArgs.TileCache);
+        using Image tileImage = CreateImage(sourceGeoTiff, rasterArgs.TileCache, readArea, writeArea);
 
         return tileImage.WriteToBuffer(GetExtensionString());
     }
 
     /// <inheritdoc />
-    public override bool WriteToChannel<T>(IGeoTiff sourceGeoTiff, ChannelWriter<T> tileWriter,
-                                           IWriteTilesArgs args)
+    public override bool WriteToChannel<T>(IGeoTiff sourceGeoTiff, ChannelWriter<T> tileWriter, IWriteTilesArgs args)
     {
         Bytes = WriteToEnumerable(sourceGeoTiff, args);
 
-        return Validate(false) && tileWriter.TryWrite(this as T);
+        return Bytes != null && Validate(false) && tileWriter.TryWrite(this as T);
     }
 
     /// <inheritdoc />
@@ -180,8 +190,7 @@ public class RasterTile : Tile
     {
         if (!isBuffered)
         {
-            foreach (T tile in fourBaseTiles)
-                tile.Bytes = File.ReadAllBytes(tile.Path);
+            foreach (T tile in fourBaseTiles) tile.Bytes = File.ReadAllBytes(tile.Path);
         }
 
         Image[] images = new Image[4];
@@ -198,10 +207,7 @@ public class RasterTile : Tile
                 empty = false;
                 images[i] = Image.NewFromBuffer(bytes).ThumbnailImage(size.Width, size.Height);
             }
-            else
-            {
-                images[i] = Image.Black(size.Width, size.Height, BandsCount);
-            }
+            else { images[i] = Image.Black(size.Width, size.Height, BandsCount); }
         }
 
         return empty ? null : Image.Arrayjoin(images, 2);

--- a/GTiff2Tiles.Tests/Tests/Images/AreaTests.cs
+++ b/GTiff2Tiles.Tests/Tests/Images/AreaTests.cs
@@ -95,7 +95,13 @@ public sealed class AreaTests
         Area calcReadArea = null;
         Area calcWriteArea = null;
 
-        Assert.DoesNotThrow(() => (calcReadArea, calcWriteArea) = Area.GetAreas(minImgCoord, maxImgCoord, _in4326Size, minTileCoord, maxTileCoord, tileSize));
+        Assert.DoesNotThrow(() =>
+        {
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, maxImgCoord, _in4326Size, minTileCoord, maxTileCoord, tileSize);
+
+            (calcReadArea, calcWriteArea) = areas.Value;
+        });
         Assert.True(calcReadArea.OriginCoordinate == expectedReadCoord && calcReadArea.Size == expectedReadSize);
         Assert.True(calcWriteArea.OriginCoordinate == expectedWriteCoord && calcWriteArea.Size == expectedWriteSize);
     }
@@ -113,7 +119,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(null, maxImgCoord, imgSize, minTileCoord, maxTileCoord, tileSize);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(null, maxImgCoord, imgSize, minTileCoord, maxTileCoord, tileSize);
         });
     }
 
@@ -130,7 +137,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(minImgCoord, null, imgSize, minTileCoord, maxTileCoord, tileSize);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, null, imgSize, minTileCoord, maxTileCoord, tileSize);
         });
     }
 
@@ -148,7 +156,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, maxTileCoord, tileSize);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, maxTileCoord, tileSize);
         });
     }
 
@@ -165,7 +174,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(minImgCoord, maxImgCoord, null, minTileCoord, maxTileCoord, tileSize);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, maxImgCoord, null, minTileCoord, maxTileCoord, tileSize);
         });
     }
 
@@ -182,7 +192,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(minImgCoord, maxImgCoord, imgSize, null, maxTileCoord, tileSize);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, maxImgCoord, imgSize, null, maxTileCoord, tileSize);
         });
     }
 
@@ -199,7 +210,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, null, tileSize);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, null, tileSize);
         });
     }
 
@@ -217,7 +229,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, maxTileCoord, tileSize);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, maxTileCoord, tileSize);
         });
     }
 
@@ -234,7 +247,8 @@ public sealed class AreaTests
         Assert.Throws<ArgumentNullException>(() =>
         {
             // ReSharper disable once ConvertToLambdaExpressionWhenPossible
-            (Area readArea, Area writeArea) = Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, maxTileCoord, null);
+            (Area readArea, Area writeArea)? areas =
+                Area.GetAreas(minImgCoord, maxImgCoord, imgSize, minTileCoord, maxTileCoord, null);
         });
     }
 
@@ -247,8 +261,8 @@ public sealed class AreaTests
     {
         using IGeoTiff image = new Raster(_in4326, Cs4326);
 
-        using ITile tile = new RasterTile(Locations.TokyoGeodeticTmsNumber,
-                                          image.GeoCoordinateSystem, tmsCompatible: true);
+        using ITile tile = new RasterTile(Locations.TokyoGeodeticTmsNumber, image.GeoCoordinateSystem,
+                                          tmsCompatible: true);
 
         PixelCoordinate expectedReadCoord = new(0.0, 218.0);
         PixelCoordinate expectedWriteCoord = new(5.6875, 0.0);
@@ -258,7 +272,11 @@ public sealed class AreaTests
         Area calcReadArea = null;
         Area calcWriteArea = null;
 
-        Assert.DoesNotThrow(() => (calcReadArea, calcWriteArea) = Area.GetAreas(image, tile));
+        Assert.DoesNotThrow(() =>
+        {
+            (Area readArea, Area writeArea)? areas = Area.GetAreas(image, tile);
+            (calcReadArea, calcWriteArea) = areas.Value;
+        });
         Assert.True(calcReadArea.OriginCoordinate == expectedReadCoord && calcReadArea.Size == expectedReadSize);
         Assert.True(calcWriteArea.OriginCoordinate == expectedWriteCoord && calcWriteArea.Size == expectedWriteSize);
     }


### PR DESCRIPTION
Fixed System.ArgumentOutOfRangeException where readSize was <1 and an exception was thrown in the constructor of Size.

System.ArgumentOutOfRangeException at GTiff2Tiles.Core.Images.Size..ctor
Specified argument was out of the range of valid values. (Parameter 'height')
at GTiff2Tiles.Core.Images.Size..ctor
at GTiff2Tiles.Core.Images.Area.GetAreas
at GTiff2Tiles.Core.Images.Area.GetAreas
at GTiff2Tiles.Core.GeoTiffs.Raster.CreateTileImage
at GTiff2Tiles.Core.GeoTiffs.Raster.WriteTileToFile
at GTiff2Tiles.Core.GeoTiffs.Raster+<>c__DisplayClass14_0.<WriteTilesToDirectory>g__MakeTile|0
at System.Threading.Tasks.Parallel+<>c__DisplayClass19_0`1.<ForWorker>b__1
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw
at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw
at System.Threading.Tasks.Parallel+<>c__DisplayClass19_0`1.<ForWorker>b__1
at System.Threading.Tasks.TaskReplicator+Replica.Execute